### PR TITLE
Add API for commits

### DIFF
--- a/app/controllers/api/commits_controller.rb
+++ b/app/controllers/api/commits_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Api::CommitsController < ApiController
+  before_action :fetch_repo
+
+  def index
+    commits = @repo.commits.limit(50).reorder(id: VALID_SORT_DIRECTIONS[params[:sort_direction]])
+    commits = commits.unverified if params[:filter] == "unverified"
+    commits = commits.verified if params[:filter] == "verified"
+    render json: { status: "success", commits: commits }
+  end
+
+  private
+
+    def fetch_repo
+      @repo = Repo.find(params[:repo_id])
+    end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ApiController < ApplicationController
+  before_action :check_client_api_key
+
+  VALID_SORT_DIRECTIONS = Hash.new("asc").merge(
+    "asc" => "asc",
+    "desc" => "desc"
+  )
+
+  def check_client_api_key
+    return if Figaro.env.client_api_key == request.headers["HTTP_API_KEY"]
+    render json: { error: "unauthorized" }, status: :unauthorized
+  end
+end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -11,6 +11,7 @@ class Commit < ActiveRecord::Base
   scope :failed, -> { where(state: "failed") }
   scope :unchecked, -> { where(state: nil) }
   scope :verified, -> { where(state: "verified") }
+  scope :unverified, -> { where("commits.state != 'verified' or commits.state is null") }
 
   def formatted_sha1
     sha1[0..6]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,10 +13,16 @@ Wilfred::Application.routes.draw do
   resources :commits
   post "/commits/:id/remind", to: "commits#remind", as: :remind_commit
   post "/commits/:id/verify", to: "commits#verify", as: :verify_commit
-  post "/commits/:id/fail", to: "commits#fail", as: :fail_commit  
+  post "/commits/:id/fail", to: "commits#fail", as: :fail_commit
 
   authenticated :user do
     root to: "commits#index", as: :authenticated_root
+  end
+
+  scope :api do
+    scope "/repos/:repo_id" do
+      get "/commits", to: "api/commits#index"
+    end
   end
 
   root to: "public#index"


### PR DESCRIPTION
Gumroad's deployment process is a bit cumbersome, so I'm considering making little script to, in one command:
- select all the verified commits on staging up to the last unverified commit (if any)
- tell you what they are
- run the appropriate commands to deploy them in production and update the production branch

Eventually it could be updated to make hotfixes easier and clearer as to what they include and what they skip. 

This PR is necessary for that script to know which commits are verified and which aren't.