### PR TITLE
Add verify button to slack notification message

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ There are a few environment variables that must be set in `config/application.ym
 - `GH_APP_SECRET` (the secret of your GitHub application)
 - `SLACK_APP_ID` (the id of your Slack application)
 - `SLACK_APP_SECRET` (the secret of your Slack application)
+- `SLACK_SIGNING_SECRET` (slacks signing secret, used to verify requests coming from slack)
 - `SLACK_ROOM` (the Slack channel you want deploy notifications to show up in)
 - `PRODUCTION_HOST` (e.g. https://wilfred.com)
 - `DEVELOPMENT_HOST` (e.g. http://local.host:3000)

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -28,10 +28,29 @@ class Commit < ActiveRecord::Base
 
   def notify_user_to_verify(user, slack_message)
     slack_username = User.find_by_email(email).try(:slack_username)
+    verify_button = [{
+            fallback: "Are you ready to verify this commit?",
+            title: "Are you ready to verify this commit?",
+            callback_id: "verify_commit_from_slack:%s" % [id],
+            color: "#3AA3E3",
+            attachment_type: "default",
+            actions: [
+                {
+                    name: "verify",
+                    text: "Verify",
+                    type: "button",
+                    value: self.id
+                },
+            ]
+        }]
 
     if slack_username.present?
       Rails.logger.info("saying to #{slack_username}: #{slack_message}")
-      user.slack.chat_postMessage(channel: slack_username, text: slack_message, username: "Wilfred", as_user: false)
+      user.slack.chat_postMessage(channel: slack_username, 
+                                  text: slack_message, 
+                                  username: "Wilfred", 
+                                  as_user: false,
+                                  attachments: verify_button)
     end
   end
 

--- a/config/initializers/slack.rb
+++ b/config/initializers/slack.rb
@@ -1,0 +1,6 @@
+## Put slack configuration 
+
+# configures signing secret for slack, used for verify incoming request from slack
+Slack::Events.configure do |config|
+    config.signing_secret = Figaro.env.SLACK_SIGNING_SECRET
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Wilfred::Application.routes.draw do
   post "/commits/:id/verify", to: "commits#verify", as: :verify_commit
   post "/commits/:id/fail", to: "commits#fail", as: :fail_commit
 
+  post "/commits/verify_from_slack", to: "commits#verify_from_slack", as: :verify_commit_from_slack
+
   authenticated :user do
     root to: "commits#index", as: :authenticated_root
   end


### PR DESCRIPTION
Closes #6 

Message now looks like this:

<img width="906" alt="Screen Shot 2019-06-20 at 3 04 47 PM" src="https://user-images.githubusercontent.com/1775346/59874676-d0c78b00-936c-11e9-8d41-2843cf62e9a0.png">

Also need to set request_url[ in slack settings](https://api.slack.com/apps/AKRT20NQ7/interactive-messages): 

<img width="1100" alt="Screen Shot 2019-06-20 at 12 50 19 PM" src="https://user-images.githubusercontent.com/1775346/59874730-feaccf80-936c-11e9-99a3-7a2f356b2aee.png">

I used [localtunnel](https://github.com/localtunnel/localtunnel) for development
