### PR TITLE
Increase past commit count from 25 to 50

### DIFF
--- a/app/controllers/commits_controller.rb
+++ b/app/controllers/commits_controller.rb
@@ -4,7 +4,7 @@ class CommitsController < ApplicationController
   skip_before_filter :verify_authenticity_token
   before_filter :fetch_commit, except: [:index]
 
-  PAST_COMMIT_COUNT = 25
+  PAST_COMMIT_COUNT = 50
 
   def index
     return redirect_to onboarding_url if current_user.incomplete?


### PR DESCRIPTION
Our team size has increased, we need to display more commits under "Verified commits" in case we need to mark a commit as bad. I was searching for a verified, but not deployed commit and wasn't able to find it in the last verified 25 commits.

@sharang-d _a please review.