### PR TITLE
Redirect if not logged in to prevent NoMethodError

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
     if user_signed_in?
       super
     else
-      redirect_to root_path, :notice => 'Please login to continue'
+      redirect_to root_path, :notice => 'Please log in to continue.'
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,13 @@
 
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  protected
+  def authenticate_user!
+    if user_signed_in?
+      super
+    else
+      redirect_to root_path, :notice => 'Please login to continue'
+    end
+  end
 end

--- a/app/controllers/commits_controller.rb
+++ b/app/controllers/commits_controller.rb
@@ -2,6 +2,7 @@
 
 class CommitsController < ApplicationController
   skip_before_filter :verify_authenticity_token
+  before_action :authenticate_user!, only: [:index]
   before_filter :fetch_commit, except: [:index]
 
   PAST_COMMIT_COUNT = 50

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,13 +4,14 @@ class UsersController < ApplicationController
   include ApplicationHelper
 
   skip_before_filter :verify_authenticity_token
+  before_action :authenticate_user!, only: [:onboarding, :onboarding_slack, :repos]
 
   def onboarding
     @organizations = current_user.github.organizations
   end
 
   def onboarding_slack
-    @name = current_user.username || current_user.email    
+    @name = current_user.username || current_user.email
   end
 
   def repos

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,10 @@
     </ul>
   </header>
 
+  <% flash.each do |message_type, message| %>
+    <h3><%= message %></h3>
+  <% end %>
+
   <div class="content yield"> 
     <%= yield %>
   </div>

--- a/test/functional/commits_controller_test.rb
+++ b/test/functional/commits_controller_test.rb
@@ -8,6 +8,6 @@ class CommitsControllerTest < ActionController::TestCase
   test "redirect from /commits if not logged in" do  
     get :index
     assert_redirected_to(controller: "public")
-    assert_equal("Please login to continue", flash[:notice])
+    assert_equal("Please log in to continue.", flash[:notice])
   end
 end

--- a/test/functional/commits_controller_test.rb
+++ b/test/functional/commits_controller_test.rb
@@ -3,4 +3,11 @@
 require "test_helper"
 
 class CommitsControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+
+  test "redirect from /commits if not logged in" do  
+    get :index
+    assert_redirected_to(controller: "public")
+    assert_equal("Please login to continue", flash[:notice])
+  end
 end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -7,7 +7,7 @@ class UsersControllerTest < ActionController::TestCase
 
   def assert_redirect
     assert_redirected_to(controller: "public")
-    assert_equal("Please login to continue", flash[:notice])
+    assert_equal("Please log in to continue.", flash[:notice])
   end
 
   test "redirect from /onboarding if not logged in" do  

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UsersControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+
+  def assert_redirect
+    assert_redirected_to(controller: "public")
+    assert_equal("Please login to continue", flash[:notice])
+  end
+
+  test "redirect from /onboarding if not logged in" do  
+    get :onboarding
+    assert_redirect
+  end
+  
+  test "redirect from /onboarding/slack if not logged in" do  
+    get :onboarding_slack
+    assert_redirect
+  end
+end


### PR DESCRIPTION
**What**
When visiting some routes (ie. /commits) and the session already expired, the app will crash. The crash caused by NoMethodError because the controller would call a method on non-logged in user. Example:

```rb
class CommitsController < ApplicationController
  # ...
  def index
    return redirect_to onboarding_url if current_user.incomplete? # <- Calling `#incomplete?` on nil
```

This PR adds redirect flow to prevent the crash; instead of crashing, redirect the user to root path and display a notice. 

Before and after:
![image](https://user-images.githubusercontent.com/7823011/132966601-fad4ee1f-1aba-4330-9bb9-70cf1936fdc1.png)
